### PR TITLE
Update to 0.8.7 and make matches more generic between versions

### DIFF
--- a/beatoraja.py
+++ b/beatoraja.py
@@ -19,7 +19,8 @@ class Quit(Scene):
 SCENE_MATCHES = {
     'bms.player.beatoraja.SystemSoundManager shuffle': Select,
     'bms.player.beatoraja.play.BMSPlayer create': Play,
-    'bms.player.beatoraja.MainController$IRSendStatus send': Result,
+    'bms.player.beatoraja.result.MusicResult updateScoreDatabase': Result,
+    'bms.player.beatoraja.PlayDataAccessor writeScoreData': Result,
     'alc_cleanup:': Quit,
     'bms.player.beatoraja.MainController dispose': Quit,
 }

--- a/beatoraja.py
+++ b/beatoraja.py
@@ -15,11 +15,11 @@ class Result(Scene):
 
 class Quit(Scene):
     pass
-
+    
 SCENE_MATCHES = {
-    'bms.player.beatoraja.MainController$SystemSoundManager shuffle': Select,
+    'bms.player.beatoraja.SystemSoundManager shuffle': Select,
     'bms.player.beatoraja.play.BMSPlayer create': Play,
-    'bms.player.beatoraja.result.MusicResult$IRSendStatus': Result,
+    'bms.player.beatoraja.MainController$IRSendStatus send': Result,
     'alc_cleanup:': Quit,
     'bms.player.beatoraja.MainController dispose': Quit,
 }

--- a/beatoraja.py
+++ b/beatoraja.py
@@ -17,6 +17,7 @@ class Quit(Scene):
     pass
     
 SCENE_MATCHES = {
+    'bms.player.beatoraja.MainController$SystemSoundManager shuffle': Select,
     'bms.player.beatoraja.SystemSoundManager shuffle': Select,
     'bms.player.beatoraja.play.BMSPlayer create': Play,
     'bms.player.beatoraja.result.MusicResult updateScoreDatabase': Result,


### PR DESCRIPTION
This PR adds support for beatoraja 0.8.7 without breaking compatibility with older versions of the game. This PR also supports a fork of the upstream project.

Beatoraja updated to 0.8.7 recently and with that came a [refactor](https://github.com/exch-bms2/beatoraja/commit/33a17d3bfbdf7fa91f108f12a137d1e66dda1831) to `MainController` splitting `SystemSoundManager` into it's own full class. Instead of breaking compatibility with older versions and causing confusion this PR supports both old and new by adding a new scene match entry.

Support for a fork of beatoraja, LR2oraja Endless Dream, has also been added, as under certain conditions that fork elects not to save or submit scores to IR (if they are using a negative rate modifier for instance). As a result the old `IRSendStatus` match would never trigger.

